### PR TITLE
Tag Checker - Add validation to Email parameter 

### DIFF
--- a/tags/tag_checker_policy/changelog.md
+++ b/tags/tag_checker_policy/changelog.md
@@ -1,5 +1,9 @@
 Tag Checker Policy changelog
 
+v1.3
+-----
+- add regex validation to "email addresses" parameter
+
 v1.2
 -----
 - bugfix issue [#31](https://github.com/rightscale/policies/issues/31)

--- a/tags/tag_checker_policy/tag_checker.cat.rb
+++ b/tags/tag_checker_policy/tag_checker.cat.rb
@@ -27,7 +27,7 @@ name 'Tag Checker'
 rs_ca_ver 20161221
 short_description "![Tag](https://s3.amazonaws.com/rs-pft/cat-logos/tag.png)\n
 Check for a tag and report which instances are missing it."
-long_description "Version: 1.2"
+long_description "Version: 1.3"
 
 ##################
 # User inputs    #

--- a/tags/tag_checker_policy/tag_checker.cat.rb
+++ b/tags/tag_checker_policy/tag_checker.cat.rb
@@ -45,6 +45,7 @@ parameter "param_email" do
   category "Contact"
   label "Email addresses (separate with commas)"
   type "string"
+  allowed_pattern '^([a-zA-Z0-9-_.]+[@]+[a-zA-Z0-9-_.]+[.]+[a-zA-Z0-9-_]+,*)+$'
   min_length 6
 end
 


### PR DESCRIPTION
Added a logic (regex) to validate if the email is a valid format.

### Description

[Describe what this change achieves] Added a regex to validate the email is a valid format user@domain.com

Tested in https://selfservice-3.rightscale.com/manager/exe/5a15479b84d0932742adfae0
Test CAT - https://selfservice-3.rightscale.com/designer/launch/59f9598d09ae740b4c7fee85

### Issues Resolved

[List any existing issues this PR resolves] N/A

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD