### PR TITLE
Tag Checker Policy: use resource name in report if it's available

### DIFF
--- a/tags/tag_checker_policy/README.md
+++ b/tags/tag_checker_policy/README.md
@@ -5,6 +5,9 @@
 Uses RightScale Cloud Language (RCL) to check all instances in an account for a given tag key and reports back which
 servers or instances are missing the tag.
 
+**Instance Names**
+The report will show the name or the resource_uid of the resource.  If the resource doesn't have an instance name then it will display the resource_uid.  For resources that do not have a name, you can follow the resource link and provide name.  The next report will have the new resource name
+
 **Using Advanced Tags**
 
 You can create a custom tag policy by using a JSON object that contains the tags, keys and validation value(s).  There are three options; string, regex and array.  You may include JSON in the field *Tags' Namespace:Keys Advanced List.* or provide a public url that contains your JSON.  The first key is the tag to match, each key has two other keys: validation-type is either array, string or regex.  validation includes the values the tag must contain.  If the tags and values are not on the server than the server will be reported in the email at the end of the cloudapp exectuion.

--- a/tags/tag_checker_policy/tag_checker.cat.rb
+++ b/tags/tag_checker_policy/tag_checker.cat.rb
@@ -320,7 +320,11 @@ define send_tags_alert_email($tags,$to) do
     else
       # Get instance name
       if $server_object["details"][0]["state"] == 'provisioned'
-        $instance_name = $server_object["details"][0]["resource_uid"]
+        # try for the instance name first, then get resource_uid
+        $instance_name = $server_object["details"][0]["name"]
+        if !$instance_name
+          $instance_name = $server_object["details"][0]["resource_uid"]
+        end
       else
         $instance_name = $server_object["details"][0]["name"]
       end


### PR DESCRIPTION
### Description
Display the resource name in the report.  If the resource name isn't available display the resource_uid

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD