### PR TITLE
Stop/Start Scheduler Policy: updating to ignore locked servers and eph store

### DIFF
--- a/instances/stop_start_scheduler/CHANGELOG.md
+++ b/instances/stop_start_scheduler/CHANGELOG.md
@@ -1,5 +1,10 @@
 Stop/Start Scheduler Policy Changelog
 
+v1.1
+-----
+- Do not try to stop locked instances
+- Ignore errors on servers with ephemeral stores
+
 v1.0
 -----
 - initial release

--- a/instances/stop_start_scheduler/README.md
+++ b/instances/stop_start_scheduler/README.md
@@ -2,8 +2,9 @@ Stop/Start Scheduler
 
 **What it does**
 
-Starts or stops instances based on a given schedule."
-long_description "This automated policy CloudApp will find instances specifically tagged
+Starts or stops instances based on a given schedule.
+
+This automated policy CloudApp will find instances specifically tagged
 for start or stop/terminate based on a specific schedule.
 
 It is recommended to run this CloudApp with the 'Always On' schedule

--- a/instances/stop_start_scheduler/stop_start_scheduler.rb
+++ b/instances/stop_start_scheduler/stop_start_scheduler.rb
@@ -1123,12 +1123,12 @@ define get_stopping_instance_state($href) return $state do
     @instance = rs_cm.get(href: $href)
     if (@instance.state =~ /^(running|operational|stranded)$/)
       if @instance.locked
-        $state = join([@instance.state, " - locked"])
+        $state = "Unstoppable(locked)"
       else
-        $state = join(["Unstoppable - ", @instance.state])
+        $state = "Unstoppable(other)"
       end
     else
-      $state = @instance.state
+      $state = "Stopped"
     end
   end
   call audit_log('> ' + @instance.name + ': Stopping ...', to_s(@instance) + ", state: " + $state)


### PR DESCRIPTION
### Description

Ignores instances that are locked on stop, and ignores errors stopping certain instances

### Issues Resolved
#11 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rightscale/policies/67)
<!-- Reviewable:end -->
