### PR TITLE
Uav permissions declaration

### DIFF
--- a/volumes/unattached_volume_policy/changelog.md
+++ b/volumes/unattached_volume_policy/changelog.md
@@ -7,3 +7,6 @@ v1.0
 v1.1 
 - Added csv file with email
 - Added Auto Terminate of the CAT once completed task.  
+
+v1.2
+- Added permission declaration.

--- a/volumes/unattached_volume_policy/unattached_volume_policy.cat.rb
+++ b/volumes/unattached_volume_policy/unattached_volume_policy.cat.rb
@@ -32,8 +32,14 @@ import "sys_log"
 #03/02/2018
 # adding auto terminate once completed.
 
-
-
+##################
+# Permissions    #
+##################
+# actor role is sufficient #
+permission "pft_general_permissions" do
+  resources "rs_cm.volumes"
+  actions   "rs_cm.destroy", "rs_cm.index"
+end
 
 ##################
 # User inputs    #


### PR DESCRIPTION
### Description

Adds explicit permissions declaration.
This ensures the user has the correct roles when publishing the CAT.

### Issues Resolved

For these RCL-focused CATs, it's important to have permission declarations since SS can't intuit the permissions needed.

### Contribution Check List

- [ X] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD