### PR TITLE
Adding additional task_label

### DIFF
--- a/tags/tag_checker_policy/changelog.md
+++ b/tags/tag_checker_policy/changelog.md
@@ -1,5 +1,9 @@
 Tag Checker Policy changelog
 
+v2.3
+----
+- adding additional task_label and syslog output
+
 v2.2
 ----
 - bugfix issues [#75] https://github.com/rightscale/policies/issues/75


### PR DESCRIPTION
Adding additional task_label.   This CloudApp is timing out somewhere after https://github.com/rightscale/policies/blob/master/tags/tag_checker_policy/tag_checker.cat.rb#L185-L206 and so hoping the task_labels will do two things:

- Allow us to know exactly what breakpoint/step the CloudApp is on when it times out
- Provide additional feedback / status updates through SS UI for what the CloudApp Execution is currently doing

https://rightscale.zendesk.com/agent/tickets/150381